### PR TITLE
Found a typo stopping th_download.py from being executed

### DIFF
--- a/download_scripts/th_download.py
+++ b/download_scripts/th_download.py
@@ -41,7 +41,7 @@ def get_id_and_creation_date(meta_url, tiles, data_type):
         for tile_id in range(start_id, end_id + 1):
             try:
                 response = requests.get(meta_url.format(tile_id))
-                print(f"\Requesting meta data: {tile_id/(end_id-start_id)*100:>3.1f}%", end="")
+                print(f"\rRequesting meta data: {tile_id/(end_id-start_id)*100:>3.1f}%", end="")
                 if response.status_code == 200:
                     data = response.json()
                     if data["success"] == "true" and "object" in data:


### PR DESCRIPTION
Incorrect character escaping due to a typo. This resulted in an error message on execution:
`D:\GIT\german_open_data_download\download_scripts\th_download.py:44: SyntaxWarning: invalid escape sequence '\R'
  print(f"\Requesting meta data: {tile_id/(end_id-start_id)*100:>3.1f}%", end="")`